### PR TITLE
Implement timeframe dashboard stats

### DIFF
--- a/frontend/dashboard/src/services/api.js
+++ b/frontend/dashboard/src/services/api.js
@@ -44,8 +44,8 @@ export const userService = {
 
 // Dashboard services
 export const dashboardService = {
-    getStats: () =>
-        api.get('/dashboard/stats'),
+    getStats: (params) =>
+        api.get('/dashboard/stats', { params }),
 };
 
 // Lesson services


### PR DESCRIPTION
## Summary
- support timeframe stats in dashboard API
- pass timeframe params from dashboard frontend service

## Testing
- `go test ./...`
- `npm test` in `frontend/dashboard`
- `npm test` in `frontend/landing`


------
https://chatgpt.com/codex/tasks/task_e_684195730444832ab26ea6f5bd05ec45