### PR TITLE
Fix analytics grade sync and model training

### DIFF
--- a/app/analytics/api/routes.py
+++ b/app/analytics/api/routes.py
@@ -120,6 +120,7 @@ async def sync_grades(db: Session = Depends(get_db)):
             # Проверяем, существует ли уже такая оценка в нашей БД
             existing_grade = db.query(Grade).filter_by(
                 student_id=student.id,
+                teacher_id=row.teacher_id,
                 subject=row.subject,
                 lab_number=row.lab_number
             ).first()
@@ -128,6 +129,7 @@ async def sync_grades(db: Session = Depends(get_db)):
                 # Создаем новую запись об оценке
                 new_grade = Grade(
                     student_id=student.id,
+                    teacher_id=row.teacher_id,
                     subject=row.subject,
                     lab_number=row.lab_number,
                     grade_value=row.grade
@@ -167,6 +169,7 @@ async def train_model(
             for student, grade in query:
                 records.append({
                     "student_id": student.id,
+                    "teacher_id": grade.teacher_id,
                     "group_name": student.group_name,
                     "subject": grade.subject,
                     "lab_number": grade.lab_number,

--- a/app/analytics/ml/models.py
+++ b/app/analytics/ml/models.py
@@ -141,58 +141,6 @@ class StudentPerformancePredictor:
         logger.info(f"Модель успешно сохранена по пути: {path}")
         return path
 
-    def load_model(self, path):
-        """
-        Загрузить модель из файла
-
-        Параметры:
-        - path: путь к файлу модели
-
-        Возвращает:
-        - True если загрузка успешна, иначе False
-        """
-        try:
-            if not os.path.exists(path):
-                logger.error(f"Модель не найдена по пути: {path}")
-                return False
-
-            # Загружаем модель
-            model_state = torch.load(path, map_location=self.device)
-
-            # Устанавливаем параметры
-            self.model_type = model_state['model_type']
-            self.feature_dim = model_state['feature_dim']
-            self.seq_length = model_state['seq_length']
-            self.scaler_X = model_state['scaler_X']
-            self.scaler_y = model_state['scaler_y']
-
-            # Пересоздаем модель с правильными параметрами
-            if self.model_type == 'lstm':
-                self.model = LSTMModel(
-                    input_dim=self.feature_dim,
-                    hidden_dim=64,
-                    num_layers=2,
-                    output_dim=1
-                ).to(self.device)
-            elif self.model_type == 'transformer':
-                self.model = TransformerModel(
-                    input_dim=self.feature_dim,
-                    model_dim=64,
-                    num_heads=4,
-                    num_layers=2,
-                    output_dim=1
-                ).to(self.device)
-
-            # Загружаем веса модели
-            self.model.load_state_dict(model_state['model_state_dict'])
-            self.model.eval()  # Переводим модель в режим оценки
-
-            logger.info(f"Модель успешно загружена из: {path}")
-            return True
-        except Exception as e:
-            logger.error(f"Ошибка при загрузке модели: {str(e)}")
-            return False
-
     def prepare_data(self, grades_data):
         """
         Подготовка данных для обучения и прогнозирования

--- a/app/analytics/models/models.py
+++ b/app/analytics/models/models.py
@@ -26,6 +26,7 @@ class Grade(Base):
 
     id = Column(Integer, primary_key=True)
     student_id = Column(Integer, ForeignKey('analytics_students.id'), nullable=False)
+    teacher_id = Column(Integer, nullable=False, index=True)
     subject = Column(String, nullable=False)
     lab_number = Column(Integer, nullable=False)
     grade_value = Column(Integer, nullable=False)


### PR DESCRIPTION
## Summary
- store teacher_id for grades and keep it during sync
- remove unused load_model method
- include teacher_id in training dataset

## Testing
- `flake8 app/analytics/api/routes.py app/analytics/ml/models.py app/analytics/models/models.py`
- `python -m py_compile app/analytics/api/routes.py app/analytics/ml/models.py app/analytics/models/models.py`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6866dcef94c8832a9397b3f2c9644ea7